### PR TITLE
bug fix, created a short circuit where sometimes the anime title does…

### DIFF
--- a/client/src/components/AnimeCards.jsx
+++ b/client/src/components/AnimeCards.jsx
@@ -32,7 +32,13 @@ const AnimeCards = ({ title, data }) => {
                 />
                 <div className="absolute top-0 left-0 w-full h-full hover:bg-black/80 opacity-0 hover:opacity-100 text-white font-sans">
                   <p className="white-space-normal text-xs md:text-sm font-bold flex justify-center items-center h-full font-sans text-center">
-                    {truncateString(anime.title.english, 25)}
+                    {truncateString(
+                      anime.title?.english ||
+                        anime.title?.romaji ||
+                        anime.title?.userPreferred ||
+                        anime.title?.native,
+                      25
+                    )}
                   </p>
                   <p>
                     {like ? (


### PR DESCRIPTION
Issues:

Anime Card throws errors due to some anime title doesn't have english as property.

Fix:

Created a short circuit to make sure to it doesn't throw an error if title doesn't have english.